### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,6 +2,9 @@
 
 name: Kick-gitlab-CI CD deploy to dev1.fhir.nmdp.org
 
+permissions:
+  contents: read
+
 # Controls when the workflow will run
 on:
   # Triggers the workflow on push or pull request events but only for the "master" branch


### PR DESCRIPTION
Potential fix for [https://github.com/nmdp-ig/matchsync-ig/security/code-scanning/1](https://github.com/nmdp-ig/matchsync-ig/security/code-scanning/1)

To fix the issue, we will add a `permissions` block to the workflow. This block will explicitly define the permissions required for the workflow, limiting the `GITHUB_TOKEN` to read-only access to repository contents. Since the workflow does not perform any repository modifications, `contents: read` is sufficient.

The `permissions` block will be added at the root level of the workflow file to apply to all jobs in the workflow. This ensures that the permissions are consistently enforced across all jobs.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
