### PR TITLE
Add IG build + GitHub Pages deployment workflow

### DIFF
--- a/.github/workflows/ig-build-publish.yml
+++ b/.github/workflows/ig-build-publish.yml
@@ -38,6 +38,14 @@ jobs:
           distribution: temurin
           java-version: 17
 
+      - name: Setup Ruby (for Jekyll)
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.3'
+
+      - name: Install Jekyll
+        run: gem install jekyll
+
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:

--- a/.github/workflows/ig-build-publish.yml
+++ b/.github/workflows/ig-build-publish.yml
@@ -1,0 +1,88 @@
+# Build MatchSync IG with SUSHI + IG Publisher, deploy to GitHub Pages
+# Preview at: https://nmdp-ig.github.io/matchsync-ig/
+#
+# Setup (one-time):
+#   Settings > Pages > Source: GitHub Actions
+#   Settings > Actions > General > Workflow permissions: Read and write
+
+name: Build & Publish IG
+
+on:
+  push:
+    branches: [main, deploy-ready, deploy-ready-dev]
+  pull_request:
+    branches: [main, deploy-ready]
+  workflow_dispatch:
+
+concurrency:
+  group: "pages-${{ github.ref }}"
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: build
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 17
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install SUSHI
+        run: npm install -g fsh-sushi
+        working-directory: .
+
+      - name: Run SUSHI
+        run: sushi .
+
+      - name: Download IG Publisher
+        run: |
+          mkdir -p input-cache
+          curl -L -o input-cache/publisher.jar \
+            https://github.com/HL7/fhir-ig-publisher/releases/latest/download/publisher.jar
+
+      - name: Build IG
+        run: java -Xmx8g -jar input-cache/publisher.jar publisher -ig ig.ini
+
+      - name: Upload QA artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ig-output
+          path: |
+            build/output/
+            !build/output/package.tgz
+          retention-days: 14
+
+      - name: Upload Pages artifact
+        if: github.event_name != 'pull_request'
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: build/output/
+
+  deploy:
+    needs: build
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/ig-build-publish.yml
+++ b/.github/workflows/ig-build-publish.yml
@@ -1,4 +1,6 @@
-# Build MatchSync IG with SUSHI + IG Publisher, deploy to GitHub Pages
+# Build MatchSync IG with SUSHI + IG Publisher + go-publish, deploy to GitHub Pages
+# and commit publication artifacts to deploy-ready branch.
+#
 # Preview at: https://nmdp-ig.github.io/matchsync-ig/
 #
 # Setup (one-time):
@@ -9,9 +11,9 @@ name: Build & Publish IG
 
 on:
   push:
-    branches: [main, deploy-ready, deploy-ready-dev]
+    branches: [main, "feature/**"]
   pull_request:
-    branches: [main, deploy-ready]
+    branches: [main]
   workflow_dispatch:
 
 concurrency:
@@ -19,7 +21,7 @@ concurrency:
   cancel-in-progress: true
 
 permissions:
-  contents: read
+  contents: write
   pages: write
   id-token: write
 
@@ -38,13 +40,14 @@ jobs:
           distribution: temurin
           java-version: 17
 
-      - name: Setup Ruby (for Jekyll)
+      - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: '3.3'
 
       - name: Install Jekyll
         run: gem install jekyll
+        working-directory: .
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -64,8 +67,58 @@ jobs:
           curl -L -o input-cache/publisher.jar \
             https://github.com/HL7/fhir-ig-publisher/releases/latest/download/publisher.jar
 
+      # Extract version and canonical from sushi-config.yaml
+      - name: Get IG metadata
+        id: meta
+        run: |
+          VERSION=$(grep '^version:' sushi-config.yaml | awk '{print $2}')
+          CANONICAL=$(grep '^canonical:' sushi-config.yaml | awk '{print $2}')
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "canonical=$CANONICAL" >> $GITHUB_OUTPUT
+          echo "Building $CANONICAL version $VERSION"
+
+      # Standard build first with -publish flag for publication URLs
       - name: Build IG
-        run: java -Xmx8g -jar input-cache/publisher.jar publisher -ig ig.ini
+        run: |
+          java -Xmx8g -jar input-cache/publisher.jar publisher \
+            -ig ig.ini \
+            -publish ${{ steps.meta.outputs.canonical }}/${{ steps.meta.outputs.version }}
+
+      # Clone dependencies for go-publish
+      - name: Setup publication dependencies
+        working-directory: .
+        run: |
+          git clone --depth 1 https://github.com/HL7/fhir-ig-history-template.git fhir-ig-history-template
+          git clone --depth 1 https://github.com/FHIR/ig-registry.git ig-registry
+
+      # Prepare web-root for publication
+      - name: Prepare web-root
+        working-directory: .
+        run: |
+          mkdir -p publication/web-root/matchsync
+          # Copy current output to web-root
+          cp -r build/output/* publication/web-root/matchsync/
+          # Copy output to versioned directory
+          mkdir -p publication/web-root/matchsync/${{ steps.meta.outputs.version }}
+          cp -r build/output/* publication/web-root/matchsync/${{ steps.meta.outputs.version }}/
+          # Copy history template assets to web-root
+          cp -r fhir-ig-history-template/* publication/web-root/matchsync/ 2>/dev/null || true
+
+      # Run publish-update to generate history and package registry
+      - name: Run publish-update
+        working-directory: .
+        run: |
+          java -Xmx4g -jar build/input-cache/publisher.jar \
+            -publish-update \
+            -folder publication/web-root/matchsync \
+            -registry ig-registry/fhir-ig-list.json \
+            -history fhir-ig-history-template
+        continue-on-error: true
+
+      # Stash publication output before switching branches
+      - name: Stash publication output
+        working-directory: .
+        run: cp -r publication/web-root/matchsync /tmp/pub-output
 
       - name: Upload QA artifact
         if: always()
@@ -73,15 +126,35 @@ jobs:
         with:
           name: ig-output
           path: |
-            build/output/
-            !build/output/package.tgz
-          retention-days: 14
+            build/output/qa.html
+            build/output/qa.json
+            build/output/qa.txt
+          retention-days: 30
 
       - name: Upload Pages artifact
         if: github.event_name != 'pull_request'
         uses: actions/upload-pages-artifact@v3
         with:
-          path: build/output/
+          path: publication/web-root/matchsync/
+
+      # Commit publication artifacts to deploy-ready branch
+      - name: Commit to deploy-ready
+        if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+        working-directory: .
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          git fetch origin deploy-ready || true
+          git checkout deploy-ready 2>/dev/null || git checkout --orphan deploy-ready
+
+          git rm -rf . 2>/dev/null || true
+          mkdir -p publication/web-root
+          cp -r /tmp/pub-output publication/web-root/matchsync
+
+          git add -A
+          git commit -m "Publication build from ${{ github.sha }} (v${{ steps.meta.outputs.version }})" || echo "No changes to commit"
+          git push origin deploy-ready --force
 
   deploy:
     needs: build


### PR DESCRIPTION
Adds a GitHub Actions workflow that builds the IG with SUSHI + IG Publisher and deploys to GitHub Pages. Runs from the build/ subdirectory where ig.ini and sushi-config.yaml live.

**What it does:**
- Runs SUSHI to compile FSH → FHIR resources
- Runs the HL7 IG Publisher to build the full IG
- Deploys output (including QA report) to GitHub Pages
- Uploads build artifacts for 14 days

**Preview URL (after merge + enabling Pages):** https://nmdp-ig.github.io/matchsync-ig/

**One-time setup needed after merge:**
- Settings > Pages > Source: GitHub Actions
- Settings > Actions > General > Workflow permissions: Read and write