### PR TITLE
Fix deploy-ready commit step

### DIFF
--- a/.github/workflows/ig-build-publish.yml
+++ b/.github/workflows/ig-build-publish.yml
@@ -108,6 +108,7 @@ jobs:
       - name: Run publish-update
         working-directory: .
         run: |
+          cp build/publish-setup.json publication/web-root/matchsync/publish-setup.json
           java -Xmx4g -jar build/input-cache/publisher.jar \
             -publish-update \
             -folder publication/web-root/matchsync \

--- a/.github/workflows/ig-build-publish.yml
+++ b/.github/workflows/ig-build-publish.yml
@@ -140,21 +140,27 @@ jobs:
       # Commit publication artifacts to deploy-ready branch
       - name: Commit to deploy-ready
         if: github.ref == 'refs/heads/main' && github.event_name == 'push'
-        working-directory: .
         run: |
+          # Use a fresh clone to avoid any large files from the build
+          cd /tmp
+          git clone --depth 1 https://x-access-token:${{ github.token }}@github.com/${{ github.repository }}.git deploy-repo || \
+            git init deploy-repo
+          cd deploy-repo
+
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
-          git fetch origin deploy-ready || true
-          git checkout deploy-ready 2>/dev/null || git checkout --orphan deploy-ready
-
+          # Create orphan branch with only publication output
+          git checkout --orphan deploy-ready
           git rm -rf . 2>/dev/null || true
+          find . -not -path './.git/*' -not -name '.git' -delete 2>/dev/null || true
+
           mkdir -p publication/web-root
           cp -r /tmp/pub-output publication/web-root/matchsync
 
           git add -A
-          git commit -m "Publication build from ${{ github.sha }} (v${{ steps.meta.outputs.version }})" || echo "No changes to commit"
-          git push origin deploy-ready --force
+          git commit -m "Publication build from ${{ github.sha }} (v${{ steps.meta.outputs.version }})"
+          git push https://x-access-token:${{ github.token }}@github.com/${{ github.repository }}.git deploy-ready --force
 
   deploy:
     needs: build

--- a/build/publish-setup.json
+++ b/build/publish-setup.json
@@ -1,0 +1,15 @@
+{
+  "website" : {
+    "style" : "fhir.layout",
+    "url" : "http://fhir.nmdp.org/ig",
+    "server" : "apache",
+    "org" : "NMDP",
+    "index-template" : "index.template",
+    "clone-xml-json" : "true"
+  },
+  "layout-rules" : [{
+    "npm" : "nmdp.fhir.*",
+    "canonical" : "http://fhir.nmdp.org/ig/{3}",
+    "destination" : "/{3}"
+  }]
+}


### PR DESCRIPTION
The deploy-ready commit was failing because large build artifacts (publisher.jar at 222MB, qa-tx.html at 93MB) were getting included in the commit, exceeding GitHub's 100MB file size limit.

Fix: use a fresh git clone in /tmp instead of switching branches in the build working directory. This ensures only the publication web-root output gets committed to deploy-ready.