### PR TITLE
Fix GitHub Pages: deploy built IG output instead of publication web-root

### DIFF
--- a/.github/workflows/ig-build-publish.yml
+++ b/.github/workflows/ig-build-publish.yml
@@ -136,7 +136,7 @@ jobs:
         if: github.event_name != 'pull_request'
         uses: actions/upload-pages-artifact@v3
         with:
-          path: publication/web-root/matchsync/
+          path: build/output/
 
       # Commit publication artifacts to deploy-ready branch
       - name: Commit to deploy-ready


### PR DESCRIPTION
The GitHub Pages site was showing raw template placeholders (`[%title%]`, `[%id%]`) instead of the actual IG content. This happened because the Pages artifact was being uploaded from `publication/web-root/matchsync/` (which contains history template files from the publish-update step) instead of `build/output/` (which has the actual rendered HTML from the IG Publisher).

One-line fix: change the Pages upload path from `publication/web-root/matchsync/` to `build/output/`.

After merge, https://nmdp-ig.github.io/matchsync-ig/ should look like https://fhir.nmdp.org/ig/matchsync/