### PR TITLE
Deploy full publication web-root to GitHub Pages (with versioned directories)

### DIFF
--- a/.github/workflows/ig-build-publish.yml
+++ b/.github/workflows/ig-build-publish.yml
@@ -96,13 +96,15 @@ jobs:
         working-directory: .
         run: |
           mkdir -p publication/web-root/matchsync
-          # Copy current output to web-root
+          # Copy history template first (provides history.html, history.js, etc.)
+          cp -r fhir-ig-history-template/* publication/web-root/matchsync/ 2>/dev/null || true
+          # Then overlay IG output on top (rendered files take precedence over template placeholders)
           cp -r build/output/* publication/web-root/matchsync/
           # Copy output to versioned directory
           mkdir -p publication/web-root/matchsync/${{ steps.meta.outputs.version }}
           cp -r build/output/* publication/web-root/matchsync/${{ steps.meta.outputs.version }}/
-          # Copy history template assets to web-root
-          cp -r fhir-ig-history-template/* publication/web-root/matchsync/ 2>/dev/null || true
+          # Copy package-list.json with all published versions (for history page)
+          cp build/package-list.json publication/web-root/matchsync/package-list.json
 
       # Run publish-update to generate history and package registry
       - name: Run publish-update
@@ -136,7 +138,7 @@ jobs:
         if: github.event_name != 'pull_request'
         uses: actions/upload-pages-artifact@v3
         with:
-          path: build/output/
+          path: publication/web-root/matchsync/
 
       # Commit publication artifacts to deploy-ready branch
       - name: Commit to deploy-ready

--- a/README.md
+++ b/README.md
@@ -107,9 +107,10 @@ sushi .
 
 ### Version Bumps
 
-Update the version in both files when releasing:
+Update these three files when releasing a new version:
 - `build/sushi-config.yaml` → `version:`
 - `build/publication-request.json` → `version:` and `path:`
+- `build/package-list.json` → add a new entry to the `list` array (this drives the history page)
 
 ## Pipeline Details
 

--- a/build/ig.ini
+++ b/build/ig.ini
@@ -1,3 +1,4 @@
 [IG]
 ig = fsh-generated/resources/ImplementationGuide-nmdp.fhir.matchsync.json
+template = nmdp-template
 template = fhir.base.template#current

--- a/build/input/pagecontent/Downloads.md
+++ b/build/input/pagecontent/Downloads.md
@@ -1,3 +1,4 @@
-# Downloads
+### Downloads
 
-Download link for the Patient Import Postman Collection.
+- [Matchsync Postman Collection](Matchsync-Postman-Collection.zip) - Postman collection for testing MatchSync API endpoints
+- [Matchsync Setup Guide](NMDP-PatientImport-Guide-v3.56.pdf) - Patient Import setup guide (PDF)

--- a/build/nmdp-template/content/assets/css/nmdp.css
+++ b/build/nmdp-template/content/assets/css/nmdp.css
@@ -1,0 +1,36 @@
+/* NMDP IG Template - Blue header theme */
+:root {
+  --navbar-bg-color: #00355E;
+  --footer-bg-color: #EAEAEB;
+  --footer-container-bg-color: #00355E;
+  --btn-hover-color: #41B8FF;
+  --stripe-bg-color: #EAEAEB;
+  --btn-active-color: #0078a6;
+  --btn-text-color: #e6e6e6;
+  --stu-note-background-color: #ffe3c8;
+  --stu-note-border-left-color: #ea7200;
+  --ig-header-color: #ffffff;
+  --ig-header-container-color: #ffffff;
+  --link-color: #428bca;
+  --link-hover-color: #2a6496;
+  --ig-status-text-color: #003C60;
+  --toc-box-bg-color: #F3F6D3;
+  --toc-box-border: 1px solid #5F6615;
+  --publish-box-bg-color: #fdf0d6;
+  --publish-box-border: 1px solid #0A0008;
+}
+
+#nmdp-nav {
+  line-height: 50px;
+  float: left;
+  margin-top: 4px;
+}
+
+#nmdp-nav a {
+  color: inherit;
+}
+
+#nmdp-logo {
+  float: left;
+  margin-left: 6px;
+}

--- a/build/nmdp-template/includes/_append.fragment-css.html
+++ b/build/nmdp-template/includes/_append.fragment-css.html
@@ -1,0 +1,1 @@
+<link href="{{site.data.info.assets}}assets/css/nmdp.css" rel="stylesheet" />

--- a/build/nmdp-template/includes/_append.fragment-footer.html
+++ b/build/nmdp-template/includes/_append.fragment-footer.html
@@ -1,0 +1,6 @@
+<div id="nmdp-footer">
+    <p>
+    <br/>HL7&#174;, and FHIR&#174; are the registered trademarks of Health Level Seven International
+        and their use of these trademarks does not constitute an endorsement by HL7.
+    </p>
+</div>

--- a/build/nmdp-template/includes/_append.fragment-header.html
+++ b/build/nmdp-template/includes/_append.fragment-header.html
@@ -1,0 +1,6 @@
+<div id="nmdp-nav">
+  <a id="nmdp-logo" no-external="true" href="http://bethematch.org">
+    <img height="50" alt="Visit the NMDP website"
+      src="{{site.data.info.assets}}assets/images/hl7-logo-header.png" />
+  </a>
+</div>

--- a/build/nmdp-template/package/package.json
+++ b/build/nmdp-template/package/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "nmdp-template",
+  "type": "fhir.template",
+  "license": "CC0-1.0",
+  "description": "NMDP IG Base Template",
+  "author": "http://bethematch.org",
+  "canonical": "http://fhir.nmdp.org/templates/nmdp-template",
+  "version": "0.1.0",
+  "base": "fhir.base.template",
+  "dependencies": {
+    "fhir.base.template": "current"
+  }
+}

--- a/build/package-list.json
+++ b/build/package-list.json
@@ -1,0 +1,62 @@
+{
+  "list" : [
+    {
+      "version" : "current",
+      "path" : "http://nmdp-ig.github.io/matchsync-ig",
+      "status" : "ci-build",
+      "sequence" : "ci-build",
+      "desc" : "Continuous Integration Build (latest in version control) - Content subject to frequent changes"
+    },
+    {
+      "version" : "0.1.4",
+      "path" : "http://fhir.nmdp.org/ig/matchsync/0.1.4",
+      "status" : "draft",
+      "sequence" : "Release",
+      "fhirversion" : "4.0.1",
+      "date" : "2026-04-22",
+      "current" : true,
+      "desc" : "Setup guide update, race/ethnicity terminology changes"
+    },
+    {
+      "version" : "0.1.3",
+      "path" : "http://fhir.nmdp.org/ig/matchsync/0.1.3",
+      "status" : "draft",
+      "sequence" : "Release",
+      "fhirversion" : "4.0.1",
+      "date" : "2025-08-27",
+      "desc" : "MatchSync IG for patient registration with NMDP"
+    },
+    {
+      "version" : "0.1.2",
+      "path" : "http://fhir.nmdp.org/ig/matchsync/0.1.2",
+      "status" : "draft",
+      "sequence" : "Release",
+      "fhirversion" : "4.0.1",
+      "date" : "2025-04-16",
+      "desc" : "MatchSync IG for patient registration with NMDP"
+    },
+    {
+      "version" : "0.1.1",
+      "path" : "http://fhir.nmdp.org/ig/matchsync/0.1.1",
+      "status" : "draft",
+      "sequence" : "Release",
+      "fhirversion" : "4.0.1",
+      "date" : "2024-06-01",
+      "desc" : "MatchSync IG for patient registration with NMDP"
+    },
+    {
+      "version" : "0.1.0",
+      "path" : "http://fhir.nmdp.org/ig/matchsync/0.1.0",
+      "status" : "draft",
+      "sequence" : "Release",
+      "fhirversion" : "4.0.1",
+      "date" : "2023-05-01",
+      "desc" : "Initial draft of MatchSync IG"
+    }
+  ],
+  "package-id" : "nmdp.fhir.matchsync",
+  "canonical" : "http://fhir.nmdp.org/ig/matchsync",
+  "title" : "MatchSync Implementation Guide",
+  "category" : "Research",
+  "introduction" : "This MatchSync Implementation Guide describes how transplant centers may use FHIR to register Patients with NMDP"
+}


### PR DESCRIPTION
Changes GitHub Pages to deploy the full publication web-root instead of just the current build output. This means versioned URLs like `/0.1.3/` will work on GitHub Pages.

Also fixes the copy order so the IG Publisher's rendered HTML overwrites the history template placeholders (which caused the `[%title%]` issue before).

After merge:
- `https://nmdp-ig.github.io/matchsync-ig/` → current version
- `https://nmdp-ig.github.io/matchsync-ig/0.1.3/` → v0.1.3
- `https://nmdp-ig.github.io/matchsync-ig/history.html` → version history