### PR TITLE
Fix: publish-update was waiting for interactive 'y' confirmation

### DIFF
--- a/.github/workflows/ig-build-publish.yml
+++ b/.github/workflows/ig-build-publish.yml
@@ -125,7 +125,7 @@ jobs:
           cp build/publish-setup.json publication/web-root/matchsync/publish-setup.json
           # Must copy AFTER the output overlay since build/output/ has its own single-version package-list.json
           cp build/package-list.json publication/web-root/matchsync/package-list.json
-          java -Xmx4g -jar build/input-cache/publisher.jar \
+          echo "y" | java -Xmx4g -jar build/input-cache/publisher.jar \
             -publish-update \
             -folder publication/web-root/matchsync \
             -registry ig-registry/fhir-ig-list.json \


### PR DESCRIPTION
The `publish-update` command prompts `Enter y to continue:` and was hanging until the step timed out. Since `continue-on-error: true` was set, it failed silently and the old `history.html` (with only 0.1.2) was never regenerated.

One-line fix: pipe `echo "y"` into the java command.

This is why the history page has been stuck showing only 0.1.2 despite the correct `package-list.json` being in place.