### PR TITLE
Fix: Inject full version list into history.html pageJSON

### DIFF
--- a/.github/workflows/ig-build-publish.yml
+++ b/.github/workflows/ig-build-publish.yml
@@ -142,6 +142,9 @@ jobs:
           # Inject NMDP CSS link into history.html
           if [ -f publication/web-root/matchsync/history.html ]; then
             sed -i 's|</head>|<link href="assets-hist/css/nmdp.css" rel="stylesheet"/>\n</head>|' publication/web-root/matchsync/history.html
+            # Fix pageJSON: replace the embedded package-list data with our full version list
+            PAGEJSON=$(cat build/package-list.json | tr -d '\n' | sed "s/'/\\\\'/g")
+            sed -i "s|var pageJSON = '.*';|var pageJSON = '${PAGEJSON}';|" publication/web-root/matchsync/history.html
           fi
 
       # Stash publication output before switching branches


### PR DESCRIPTION
The `publish-update` command runs successfully but isn't updating the `pageJSON` variable embedded in `history.html`. This is the variable that `history.js` reads to render the version table.

Fix: directly replace the `pageJSON` content in `history.html` with our full `package-list.json` using sed after the publish-update step.

This should finally show all versions (0.1.0-0.1.4) on the history page.